### PR TITLE
Vote accumulation and round-estimate logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,12 @@ use std::fmt;
 
 /// A prevote for a block and its ancestors.
 pub struct Prevote<H> {
-	round: u64,
 	target: H,
 	weight: usize,
 }
 
 /// A precommit for a block and its ancestors.
 pub struct Precommit<H> {
-	round: u64,
 	target: H,
 	weight: usize,
 }
@@ -64,4 +62,16 @@ pub trait Chain<H> {
 	///
 	/// If the block is not a descendent of `base`, returns an error.
 	fn ancestry(&self, base: H, block: H) -> Result<Vec<H>, Error>;
+}
+
+/// An equivocation (double-vote) in a given round.
+pub struct Equivocation<Id, V, S> {
+	/// The round number equivocated in.
+	pub round_number: u64,
+	/// The identity of the equivocator.
+	pub identity: Id,
+	/// The first vote in the equivocation.
+	pub	first: (V, S),
+	/// The second vote in the equivocation.
+	pub second: (V, S),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,20 +21,35 @@
 mod round;
 mod vote_graph;
 
+#[cfg(test)]
+mod testing;
+
 use std::fmt;
 
 /// A prevote for a block and its ancestors.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Prevote<H> {
 	target_hash: H,
 	target_number: u32,
 }
 
+impl<H> Prevote<H> {
+	pub fn new(target_hash: H, target_number: u32) -> Self {
+		Prevote { target_hash, target_number }
+	}
+}
+
 /// A precommit for a block and its ancestors.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Precommit<H> {
 	target_hash: H,
 	target_number: u32,
+}
+
+impl<H> Precommit<H> {
+	pub fn new(target_hash: H, target_number: u32) -> Self {
+		Precommit { target_hash, target_number }
+	}
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -68,6 +83,7 @@ pub trait Chain<H> {
 }
 
 /// An equivocation (double-vote) in a given round.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Equivocation<Id, V, S> {
 	/// The round number equivocated in.
 	pub round_number: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,15 @@ use std::fmt;
 /// A prevote for a block and its ancestors.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Prevote<H> {
-	target: H,
-	weight: usize,
+	target_hash: H,
+	target_number: u32,
 }
 
 /// A precommit for a block and its ancestors.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Precommit<H> {
-	target: H,
-	weight: usize,
+	target_hash: H,
+	target_number: u32,
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,20 @@
 //!
 //! https://hackmd.io/iA4XazxWRJ21LqMxwPSEZg?view
 
+mod round;
 mod vote_graph;
 
 use std::fmt;
 
 /// A prevote for a block and its ancestors.
+#[derive(Clone, PartialEq, Eq)]
 pub struct Prevote<H> {
 	target: H,
 	weight: usize,
 }
 
 /// A precommit for a block and its ancestors.
+#[derive(Clone, PartialEq, Eq)]
 pub struct Precommit<H> {
 	target: H,
 	weight: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Finality gadget for blockchains.
 //!
-//! https://hackmd.io/svMTltnGQsSR1GCjRKOPbw
+//! https://hackmd.io/iA4XazxWRJ21LqMxwPSEZg?view
 
 mod vote_graph;
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -1,0 +1,75 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// This file is part of finality-afg.
+
+// finality-afg is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// finality-afg is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with finality-afg. If not, see <http://www.gnu.org/licenses/>.
+
+//! Logic for a single round of AfG.
+
+use vote_graph::VoteGraph;
+
+use std::collections::hash_map::{HashMap, Entry};
+use std::hash::Hash;
+use std::ops::AddAssign;
+
+use super::Equivocation;
+
+#[derive(Hash, Eq, PartialEq)]
+struct Address;
+
+#[derive(Debug, Clone)]
+struct VoteCount {
+	prevote: usize,
+	precommit: usize,
+}
+
+impl AddAssign for VoteCount {
+	fn add_assign(&mut self, rhs: VoteCount) {
+		*self.prevote += rhs.prevote;
+		*self.precommit += rhs.precommit;
+	}
+}
+
+struct VoteTracker<Id: Hash + Eq, Vote, Signature> {
+	votes: HashMap<Id, (Vote, Signature)>,
+	current_weight: usize,
+}
+
+impl<Id: Hash + Eq, Vote: Clone, Signature: Eq> VoteTracker<Id, Vote, Signature> {
+	fn new() -> Self {
+		VoteTracker {
+			votes: HashMap::new();
+			current_weight: 0,
+		}
+	}
+
+	// track a vote. if the vote is an equivocation, returns a proof-of-equivocation and
+	// otherwise notes the current amount of weight on the tracked vote-set
+	fn add_vote(&mut self, id: Id, vote: Vote, signature: Signature, weight: usize)
+		-> Result<(), Equivocation<Id, Vote, Signature>>
+	{
+		match self.votes.entry(id) {
+			Entry::Vacant(mut vacant) => {
+				vacant.insert((vote, signature));
+			}
+		}
+	}
+}
+
+/// Stores data for a round.
+pub struct Round<H: Hash + Eq> {
+	graph: VoteGraph<H, VoteCount>,
+	threshold_weight: usize,
+	total_weight: usize,
+	current_weight: usize,
+}

--- a/src/round.rs
+++ b/src/round.rs
@@ -102,6 +102,7 @@ pub struct Round<Id: Hash + Eq, H: Hash + Eq, Signature> {
 	round_number: usize,
 	faulty_weight: usize,
 	total_weight: usize,
+	prevote_ghost: Option<(H, usize)>,
 }
 
 impl<Id: Hash + Clone + Eq, H: Hash + Clone + Eq + Ord, Signature: Eq + Clone> Round<Id, H, Signature> {
@@ -116,6 +117,14 @@ impl<Id: Hash + Clone + Eq, H: Hash + Clone + Eq + Ord, Signature: Eq + Clone> R
 			graph: VoteGraph::new(base_hash, base_number),
 			prevote: VoteTracker::new(),
 			precommit: VoteTracker::new(),
+			prevote_ghost: None,
 		}
+	}
+
+	/// Fetch the "round-estimate": the best block which might have been finalized
+	/// in this round.
+	pub fn estimate(&self) -> (H, usize) {
+		let remaining_commit_votes = self.total_weight - self.precommit.current_weight;
+		unimplemented!()
 	}
 }

--- a/src/round.rs
+++ b/src/round.rs
@@ -22,12 +22,12 @@ use std::collections::hash_map::{HashMap, Entry};
 use std::hash::Hash;
 use std::ops::AddAssign;
 
-use super::Equivocation;
+use super::{Equivocation, Prevote, Precommit};
 
 #[derive(Hash, Eq, PartialEq)]
 struct Address;
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 struct VoteCount {
 	prevote: usize,
 	precommit: usize,
@@ -35,8 +35,8 @@ struct VoteCount {
 
 impl AddAssign for VoteCount {
 	fn add_assign(&mut self, rhs: VoteCount) {
-		*self.prevote += rhs.prevote;
-		*self.precommit += rhs.precommit;
+		self.prevote += rhs.prevote;
+		self.precommit += rhs.precommit;
 	}
 }
 
@@ -45,31 +45,77 @@ struct VoteTracker<Id: Hash + Eq, Vote, Signature> {
 	current_weight: usize,
 }
 
-impl<Id: Hash + Eq, Vote: Clone, Signature: Eq> VoteTracker<Id, Vote, Signature> {
+impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone> VoteTracker<Id, Vote, Signature> {
 	fn new() -> Self {
 		VoteTracker {
-			votes: HashMap::new();
+			votes: HashMap::new(),
 			current_weight: 0,
 		}
 	}
 
 	// track a vote. if the vote is an equivocation, returns a proof-of-equivocation and
-	// otherwise notes the current amount of weight on the tracked vote-set
+	// otherwise notes the current amount of weight on the tracked vote-set.
+	//
+	// since this struct doesn't track the round number of votes, that must be set
+	// by the caller.
 	fn add_vote(&mut self, id: Id, vote: Vote, signature: Signature, weight: usize)
 		-> Result<(), Equivocation<Id, Vote, Signature>>
 	{
-		match self.votes.entry(id) {
+		match self.votes.entry(id.clone()) {
 			Entry::Vacant(mut vacant) => {
 				vacant.insert((vote, signature));
 			}
+			Entry::Occupied(mut occupied) => {
+				if occupied.get().0 != vote {
+					return Err(Equivocation {
+						round_number: 0,
+						identity: id,
+						first: occupied.get().clone(),
+						second: (vote, signature),
+					})
+				}
+			}
 		}
+
+		Ok(())
 	}
 }
 
+/// Parameters for starting a round.
+pub struct RoundParams<H> {
+	/// The round number for votes.
+	pub round_number: usize,
+	/// The amount of byzantine-faulty voting weight that exists (assumed) in the
+	/// system.
+	pub faulty_weight: usize,
+	/// The amount of total voting weight in the system
+	pub total_weight: usize,
+	/// The base block to build on.
+	pub base: (H, usize),
+}
+
 /// Stores data for a round.
-pub struct Round<H: Hash + Eq> {
+pub struct Round<Id: Hash + Eq, H: Hash + Eq, Signature> {
 	graph: VoteGraph<H, VoteCount>,
-	threshold_weight: usize,
+	prevote: VoteTracker<Id, Prevote<H>, Signature>,
+	precommit: VoteTracker<Id, Precommit<H>, Signature>,
+	round_number: usize,
+	faulty_weight: usize,
 	total_weight: usize,
-	current_weight: usize,
+}
+
+impl<Id: Hash + Clone + Eq, H: Hash + Clone + Eq + Ord, Signature: Eq + Clone> Round<Id, H, Signature> {
+	/// Create a new round accumulator for given round number and with given weight.
+	/// Not guaranteed to work correctly unless total_weight more than 3x larger than faulty_weight
+	pub fn new(round_params: RoundParams<H>) -> Self {
+		let (base_hash, base_number) = round_params.base;
+		Round {
+			round_number: round_params.round_number,
+			faulty_weight: round_params.faulty_weight,
+			total_weight: round_params.total_weight,
+			graph: VoteGraph::new(base_hash, base_number),
+			prevote: VoteTracker::new(),
+			precommit: VoteTracker::new(),
+		}
+	}
 }

--- a/src/round.rs
+++ b/src/round.rs
@@ -354,4 +354,42 @@ mod tests {
 		assert_eq!(round.estimate(), Some(&("E", 6)));
 	}
 
+	#[test]
+	fn finalization() {
+		let mut chain = DummyChain::new();
+		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
+		chain.push_blocks("E", &["EA", "EB", "EC", "ED"]);
+		chain.push_blocks("F", &["FA", "FB", "FC"]);
+
+		let mut round = Round::new(RoundParams {
+			round_number: 1,
+			voters: voters(),
+			base: ("C", 4),
+		});
+
+		round.import_precommit(
+			&chain,
+			Precommit::new("FC", 10),
+			"Alice",
+			Signature("Alice"),
+		).unwrap();
+
+		round.import_precommit(
+			&chain,
+			Precommit::new("ED", 10),
+			"Bob",
+			Signature("Bob"),
+		).unwrap();
+
+		assert_eq!(round.finalized, Some(("E", 6)));
+
+		round.import_precommit(
+			&chain,
+			Precommit::new("EA", 7),
+			"Eve",
+			Signature("Eve"),
+		).unwrap();
+
+		assert_eq!(round.finalized, Some(("EA", 7)));
+	}
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,77 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// This file is part of finality-afg.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with finality-afg. If not, see <http://www.gnu.org/licenses/>.
+
+//! Helpers for testing
+
+use std::collections::HashMap;
+use super::{Chain, Error};
+
+pub const GENESIS_HASH: &str = "genesis";
+const NULL_HASH: &str = "NULL";
+
+struct BlockRecord {
+	number: usize,
+	parent: &'static str,
+}
+
+pub struct DummyChain {
+	inner: HashMap<&'static str, BlockRecord>,
+}
+
+impl DummyChain {
+	pub fn new() -> Self {
+		let mut inner = HashMap::new();
+		inner.insert(GENESIS_HASH, BlockRecord { number: 1, parent: NULL_HASH });
+
+		DummyChain { inner }
+	}
+
+	pub fn push_blocks(&mut self, mut parent: &'static str, blocks: &[&'static str]) {
+		let base_number = self.inner.get(parent).unwrap().number + 1;
+		for (i, descendent) in blocks.iter().enumerate() {
+			self.inner.insert(descendent, BlockRecord {
+				number: base_number + i,
+				parent,
+			});
+
+			parent = descendent;
+		}
+	}
+
+	pub fn number(&self, hash: &'static str) -> usize {
+		self.inner.get(hash).unwrap().number
+	}
+}
+
+impl Chain<&'static str> for DummyChain {
+	fn ancestry(&self, base: &'static str, mut block: &'static str) -> Result<Vec<&'static str>, Error> {
+		let mut ancestry = Vec::new();
+
+		loop {
+			match self.inner.get(block) {
+				None => return Err(Error::BlockNotInSubtree),
+				Some(record) => { block = record.parent; }
+			}
+
+			ancestry.push(block);
+
+			if block == NULL_HASH { return Err(Error::BlockNotInSubtree) }
+			if block == base { break }
+		}
+
+		Ok(ancestry)
+	}
+}

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -68,7 +68,8 @@ impl<H, V> VoteGraph<H, V> where
 	H: Hash + Eq + Clone + Ord,
 	V: ::std::ops::AddAssign + Default + Clone,
 {
-	fn new(base_hash: H, base_number: usize) -> Self {
+	/// Create a new `VoteGraph` with base node as given.
+	pub fn new(base_hash: H, base_number: usize) -> Self {
 		let mut entries = HashMap::new();
 		entries.insert(base_hash.clone(), Entry {
 			number: base_number,

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -441,63 +441,7 @@ impl<H, V> VoteGraph<H, V> where
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	const GENESIS_HASH: &str = "genesis";
-	const NULL_HASH: &str = "NULL";
-
-	struct BlockRecord {
-		number: usize,
-		parent: &'static str,
-	}
-
-	struct DummyChain {
-		inner: HashMap<&'static str, BlockRecord>,
-	}
-
-	impl DummyChain {
-		fn new() -> Self {
-			let mut inner = HashMap::new();
-			inner.insert(GENESIS_HASH, BlockRecord { number: 1, parent: NULL_HASH });
-
-			DummyChain { inner }
-		}
-
-		fn push_blocks(&mut self, mut parent: &'static str, blocks: &[&'static str]) {
-			let base_number = self.inner.get(parent).unwrap().number + 1;
-			for (i, descendent) in blocks.iter().enumerate() {
-				self.inner.insert(descendent, BlockRecord {
-					number: base_number + i,
-					parent,
-				});
-
-				parent = descendent;
-			}
-		}
-
-		fn number(&self, hash: &'static str) -> usize {
-			self.inner.get(hash).unwrap().number
-		}
-	}
-
-	impl Chain<&'static str> for DummyChain {
-		fn ancestry(&self, base: &'static str, mut block: &'static str) -> Result<Vec<&'static str>, Error> {
-			let mut ancestry = Vec::new();
-
-			loop {
-				match self.inner.get(block) {
-					None => return Err(Error::BlockNotInSubtree),
-					Some(record) => { block = record.parent; }
-				}
-
-				ancestry.push(block);
-
-				if block == NULL_HASH { return Err(Error::BlockNotInSubtree) }
-				if block == base { break }
-			}
-
-			Ok(ancestry)
-		}
-	}
+	use testing::{GENESIS_HASH, DummyChain};
 
 	#[test]
 	fn graph_fork_not_at_node() {


### PR DESCRIPTION
Specifically this section from the latest hackmd document. Can be found in https://github.com/paritytech/finality-afg/pull/2/commits/c9d922c57c503664859b0558a2b54c98e39d3019

We define `E_r,v`, v's estimate of what might have been finalised in round r, to be the last block in the chain with head `g(V_r,v)` that it is possible for `C_r,r` to have a supermajority for. If either `E_r,v<g(V_r,v)` or it is impossible for `C_r,v` to have a supermajority for any children of `g(V_r,v)`, then we say that (v sees that) round r is completable. `E_0,v` is the genesis block (if we start at r=1).