### PR TITLE
Handle equivocations correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
+parking_lot = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 parking_lot = "0.4"
+log = "0.4"

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -175,11 +175,13 @@ impl<Id: Eq> LiveBitfield<Id> {
 		let word_off = bit_idx / 64;
 		let bit_off = bit_idx % 64;
 
-		// TODO: if this isn't `Some`, something has gone really wrong.
-		// log it?
+		// If this isn't `Some`, something has gone really wrong.
 		if let Some(word) = self.bits.get_mut(word_off) {
 			// set bit starting from left.
 			*word |= 1 << (63 - bit_off)
+		} else {
+			warn!(target: "afg", "Could not set bit {}. Bitfield was meant to have 2 bits for each of {} validators.",
+				bit_idx, self.shared.n_validators);
 		}
 	}
 

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -1,0 +1,332 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// This file is part of finality-afg.
+
+// finality-afg is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// finality-afg is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with finality-afg. If not, see <http://www.gnu.org/licenses/>.
+
+//! Bitfield for handling equivocations.
+//!
+//! This is primarily a bitfield for tracking equivocating validators.
+//! It is necessary because there is a need to track vote-weight of equivocation
+//! on the vote-graph but to avoid double-counting.
+//!
+//! Bitfields are either blank (in the general case) or live, in the case of
+//! equivocations, with two bits per equivocator. The first is for equivocations
+//! in prevote messages and the second for those in precommits.
+//!
+//! Each live bitfield carries a reference to a shared object that
+//! provides lookups from bit indices to validator weight. Bitfields can be
+//! merged, and queried for total weight in commits and precommits.
+
+use std::fmt;
+use std::ops::{BitOr, BitAnd};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use parking_lot::RwLock;
+
+// global used to ensure that conflicting shared objects are not used.
+static SHARED_IDX: AtomicUsize = AtomicUsize::new(0);
+
+/// Errors that can occur when using the equivocation weighting tools.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Error {
+	/// Too many equivocating validators registered. (shared data IDX, n_validators).
+	TooManyEquivocators(usize, usize),
+	/// Mismatch in shared data IDX when merging bitfields.
+	ContextMismatch(usize, usize),
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match *self {
+			Error::TooManyEquivocators(ref idx, ref n)
+				=> write!(f, "Registered too many equivocators for shared data with ID {}. Maximum specified was {}", idx, n),
+			Error::ContextMismatch(ref idx1, ref idx2)
+				=> write!(f, "Attempted to merge bitfields with different contexts: {} vs {}", idx1, idx2),
+		}
+	}
+}
+
+impl ::std::error::Error for Error {}
+
+/// Bitfield for equivocating validators.
+///
+/// See module docs for more details.
+#[derive(Clone)]
+pub enum Bitfield<Id> {
+	/// Blank bitfield,
+	Blank,
+	/// Live bitfield,
+	Live(LiveBitfield<Id>),
+}
+
+impl<Id: Eq> Bitfield<Id> {
+	/// Find total equivocating weight (prevote, precommit).
+	pub fn total_weight(&self) -> (usize, usize) {
+		match *self {
+			Bitfield::Blank => (0, 0),
+			Bitfield::Live(ref live) => live.total_weight(),
+		}
+	}
+
+	/// Combine two bitfields. Fails if they have conflicting shared data
+	/// (i.e. they come from different contexts).
+	pub fn merge(&self, other: &Self) -> Result<Self, Error> {
+		match (self, other) {
+			(&Bitfield::Blank, &Bitfield::Blank) => Ok(Bitfield::Blank),
+			(&Bitfield::Live(ref live), &Bitfield::Blank) | (&Bitfield::Blank, &Bitfield::Live(ref live))
+				=> Ok(Bitfield::Live(live.clone())),
+			(&Bitfield::Live(ref a), &Bitfield::Live(ref b)) => {
+				if a.shared.idx != b.shared.idx {
+					// we can't merge two bitfields from different contexts.
+					Err(Error::ContextMismatch(a.shared.idx, b.shared.idx))
+				} else {
+					let bits = a.bits.iter().zip(&b.bits).map(|(a, b)| a | b).collect();
+					Ok(Bitfield::Live(LiveBitfield { bits, shared: a.shared.clone() }))
+				}
+			}
+		}
+	}
+}
+
+/// Live bitfield instance.
+pub struct LiveBitfield<Id> {
+	bits: Vec<u64>,
+	shared: Shared<Id>,
+}
+
+impl<Id> Clone for LiveBitfield<Id> {
+	fn clone(&self) -> Self {
+		LiveBitfield {
+			bits: self.bits.clone(),
+			shared: self.shared.clone(),
+		}
+	}
+}
+
+impl<Id: Eq> LiveBitfield<Id> {
+	/// Create a new live bitfield.
+	pub fn new(shared: Shared<Id>) -> Self {
+		LiveBitfield { bits: shared.blank_bitfield(), shared }
+	}
+
+	/// Note a validator's equivocation in prevote.
+	/// Fails if more equivocators than the number of validators have
+	/// been registered.
+	pub fn equivocated_prevote(&mut self, id: Id, weight: usize) -> Result<(), Error> {
+		let val_off = self.shared.get_or_register_equivocator(id, weight)?;
+		self.set_bit(val_off * 2);
+		Ok(())
+	}
+
+	/// Note a validator's equivocation in precommit.
+	/// Fails if more equivocators than the number of validators have
+	/// been registered.
+	pub fn equivocated_precommit(&mut self, id: Id, weight: usize) -> Result<(), Error> {
+		let val_off = self.shared.get_or_register_equivocator(id, weight)?;
+		self.set_bit(val_off * 2 + 1);
+		Ok(())
+	}
+
+	fn set_bit(&mut self, bit_idx: usize) {
+		let word_off = bit_idx / 64;
+		let bit_off = bit_idx % 64;
+
+		// TODO: if this isn't `Some`, something has gone really wrong.
+		// log it?
+		if let Some(word) = self.bits.get_mut(word_off) {
+			// set bit starting from left.
+			*word |= (1 << (63 - bit_off))
+		}
+	}
+
+	// find total weight of this bitfield (prevote, precommit).
+	fn total_weight(&self) -> (usize, usize) {
+		struct State {
+			word_idx: usize,
+			prevote: usize,
+			precommit: usize,
+		};
+
+		let state = State {
+			word_idx: 0,
+			prevote: 0,
+			precommit: 0,
+		};
+
+		let validators = self.shared.validators.read();
+		let state = self.bits.iter().cloned().fold(state, |mut state, mut word| {
+			for i in 0..32 {
+				if word == 0 { break }
+
+				// prevote bit is set
+				if word & (1 << 63) == (1 << 63) {
+					state.prevote += validators[state.word_idx * 32 + i].weight;
+				}
+
+				// precommit bit is set
+				if word & (1 << 62) == (1 << 62) {
+					state.precommit += validators[state.word_idx * 32 + i].weight;
+				}
+
+				word <<= 2;
+			}
+
+			state.word_idx += 1;
+			state
+		});
+
+		(state.prevote, state.precommit)
+	}
+}
+
+/// Shared data among all live bitfield instances.
+pub struct Shared<Id> {
+	idx: usize,
+	n_validators: usize,
+	validators: Arc<RwLock<Vec<ValidatorEntry<Id>>>>
+}
+
+impl<Id> Clone for Shared<Id> {
+	fn clone(&self) -> Self {
+		Shared {
+			idx: self.idx,
+			n_validators: self.n_validators,
+			validators: self.validators.clone(),
+		}
+	}
+}
+
+impl<Id: Eq> Shared<Id> {
+	/// Create new shared equivocation detection data. Provide the number
+	/// of validators.
+	pub fn new(n_validators: usize) -> Self {
+		let idx = SHARED_IDX.fetch_add(1, Ordering::SeqCst);
+		Shared {
+			idx,
+			n_validators,
+			validators: Arc::new(RwLock::new(Vec::new())),
+		}
+	}
+
+	fn blank_bitfield(&self) -> Vec<u64> {
+		let n_bits = self.n_validators * 2;
+		let n_words = (n_bits + 63) / 64;
+
+		vec![0; n_words]
+	}
+
+	fn get_or_register_equivocator(&self, equivocator: Id, weight: usize) -> Result<usize, Error> {
+		{
+			// linear search is probably fast enough until we have thousands of
+			// equivocators. finding the bit to set is slow but happens rarely.
+			let validators = self.validators.read();
+			let maybe_found = validators.iter()
+				.enumerate()
+				.find(|&(_, ref e)| e.id == equivocator);
+
+			if let Some((idx, _)) = maybe_found {
+				return Ok(idx);
+			}
+		}
+
+		let mut validators = self.validators.write();
+		if validators.len() == self.n_validators {
+			return Err(Error::TooManyEquivocators(self.idx, self.n_validators) )
+		}
+		validators.push(ValidatorEntry { id: equivocator, weight });
+		Ok(validators.len() - 1)
+	}
+
+	// get total weight of given validator indices, ignoring any
+	// invalid indices.
+	fn total_weight<I>(&self, indices: I) -> usize where I: IntoIterator<Item=usize> {
+		let validators = self.validators.read();
+
+		indices.into_iter()
+			.filter_map(|i| validators.get(i))
+			.map(|entry| entry.weight)
+			.sum()
+	}
+}
+
+struct ValidatorEntry<Id> {
+	id: Id,
+	weight: usize,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn shared_fails_registering_too_many() {
+		let shared = Shared::new(0);
+		assert!(shared.get_or_register_equivocator(5, 1000).is_err());
+	}
+
+	#[test]
+	fn shared_register_same_many_times() {
+		let shared = Shared::new(1);
+		assert_eq!(shared.get_or_register_equivocator(5, 1000), Ok(0));
+		assert_eq!(shared.get_or_register_equivocator(5, 1000), Ok(0));
+	}
+
+	#[test]
+	fn merge_live() {
+		let mut shared = Shared::new(10);
+		let mut live_a = LiveBitfield::new(shared.clone());
+		let mut live_b = LiveBitfield::new(shared.clone());
+
+		live_a.equivocated_prevote(1, 5).unwrap();
+		live_a.equivocated_precommit(2, 7).unwrap();
+
+		live_b.equivocated_prevote(3, 9).unwrap();
+		live_b.equivocated_precommit(3, 9).unwrap();
+
+		assert_eq!(live_a.total_weight(), (5, 7));
+		assert_eq!(live_b.total_weight(), (9, 9));
+
+		let (a, b) = (Bitfield::Live(live_a), Bitfield::Live(live_b));
+
+		let c = a.merge(&b).unwrap();
+		assert_eq!(c.total_weight(), (14, 16));
+	}
+
+	#[test]
+	fn merge_with_different_shared_is_error() {
+		let shared_a: Shared<usize> = Shared::new(1);
+		let shared_b = Shared::new(1);
+
+		let bitfield_a = Bitfield::Live(LiveBitfield::new(shared_a));
+		let bitfield_b = Bitfield::Live(LiveBitfield::new(shared_b));
+
+		assert!(bitfield_a.merge(&bitfield_b).is_err());
+	}
+
+	#[test]
+	fn set_first_and_last_bits() {
+		let shared = Shared::new(32);
+		assert_eq!(shared.blank_bitfield().len(), 1);
+
+		for i in 0..32 {
+			shared.get_or_register_equivocator(i, i + 1).unwrap();
+		}
+
+		let mut live_bitfield = LiveBitfield::new(shared);
+		live_bitfield.equivocated_prevote(0, 1);
+		live_bitfield.equivocated_precommit(31, 32);
+
+		assert_eq!(live_bitfield.total_weight(), (1, 32));
+	}
+}

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -288,17 +288,6 @@ impl<Id: Eq> Shared<Id> {
 		validators.push(ValidatorEntry { id: equivocator, weight });
 		Ok(validators.len() - 1)
 	}
-
-	// get total weight of given validator indices, ignoring any
-	// invalid indices.
-	fn total_weight<I>(&self, indices: I) -> usize where I: IntoIterator<Item=usize> {
-		let validators = self.validators.read();
-
-		indices.into_iter()
-			.filter_map(|i| validators.get(i))
-			.map(|entry| entry.weight)
-			.sum()
-	}
 }
 
 #[derive(Debug)]
@@ -374,7 +363,7 @@ mod tests {
 
 	#[test]
 	fn weight_overlap() {
-		let mut shared = Shared::new(10);
+		let shared = Shared::new(10);
 		let mut live_a = LiveBitfield::new(shared.clone());
 		let mut live_b = LiveBitfield::new(shared.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@
 //!
 //! https://hackmd.io/iA4XazxWRJ21LqMxwPSEZg?view
 
+extern crate parking_lot;
+
+mod bitfield;
 mod round;
 mod vote_graph;
 
@@ -25,7 +28,6 @@ mod vote_graph;
 mod testing;
 
 use std::fmt;
-
 /// A prevote for a block and its ancestors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Prevote<H> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,9 @@
 
 extern crate parking_lot;
 
-mod bitfield;
-mod round;
-mod vote_graph;
+pub mod bitfield;
+pub mod round;
+pub mod vote_graph;
 
 #[cfg(test)]
 mod testing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //! https://hackmd.io/iA4XazxWRJ21LqMxwPSEZg?view
 
 extern crate parking_lot;
+#[macro_use]
+extern crate log;
 
 pub mod bitfield;
 pub mod round;

--- a/src/round.rs
+++ b/src/round.rs
@@ -146,7 +146,7 @@ impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone> VoteTracker<Id, 
 		-> &VoteMultiplicity<Vote, Signature>
 	{
 		match self.votes.entry(id) {
-			Entry::Vacant(mut vacant) => {
+			Entry::Vacant(vacant) => {
 				self.current_weight += weight;
 				&*vacant.insert(VoteMultiplicity::Single(vote, signature))
 			}

--- a/src/round.rs
+++ b/src/round.rs
@@ -380,7 +380,11 @@ impl<Id, H, Signature> Round<Id, H, Signature> where
 			// all the votes already applied on this block,
 			// and assuming all remaining actors commit to this block,
 			// and assuming all possible equivocations end up on this block.
-			weight.precommit + remaining_commit_votes + additional_equivocation_weight >= threshold
+			let full_possible_weight = weight.precommit
+				.saturating_add(remaining_commit_votes)
+				.saturating_add(additional_equivocation_weight);
+
+			full_possible_weight >= threshold
 		};
 
 		// until we have threshold precommits, any new block could get supermajority

--- a/src/round.rs
+++ b/src/round.rs
@@ -387,8 +387,8 @@ impl<Id, H, Signature> Round<Id, H, Signature> where
 		// precommits because there are at least f + 1 precommits remaining and then
 		// f equivocations.
 		//
-		// once it's at least that level, we only need to consider already
-		// blocks referenced in the graph, because no new leaf nodes
+		// once it's at least that level, we only need to consider blocks
+		// already referenced in the graph, because no new leaf nodes
 		// could ever have enough precommits.
 		//
 		// the round-estimate is the highest block in the chain with head

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -69,11 +69,6 @@ impl<H: Clone> Subchain<H> {
 		self.hashes.iter().rev().cloned().enumerate().map(move |(i, x)| (x, best - i))
 	}
 
-	fn block_at(&self, number: usize) -> Option<&H> {
-		let rev_off = self.best_number.checked_sub(number)?;
-		self.hashes.len().checked_sub(rev_off + 1).map(|i| &self.hashes[i])
-	}
-
 	fn best(&self) -> Option<(H, usize)> {
 		self.hashes.last().map(|x| (x.clone(), self.best_number))
 	}

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -203,6 +203,8 @@ impl<H, V> VoteGraph<H, V> where
 	/// This assumes that the evaluation closure is one which returns true for at most a single
 	/// descendent of a block, in that only one fork of a block can be "heavy"
 	/// enough to trigger the threshold.
+	///
+	/// Returns `None` when the given `current_best` does not fulfill the condition.
 	pub fn find_ghost<'a, F>(&'a self, current_best: Option<(H, usize)>, condition: F) -> Option<(H, usize)>
 		where F: Fn(&V) -> bool
 	{

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -174,8 +174,6 @@ impl<H, V> VoteGraph<H, V> where
 			Some(_) => return None,
 		};
 
-		let initial_node_key = node_key.clone();
-
 		// search backwards until we find the first vote-node that
 		// meets the condition.
 		let mut active_node = get_node(&node_key);


### PR DESCRIPTION
Closes #4

This introduces a `bitfield` module, which is used to lazily attach bitfields for equivocating (double-voting) validators as soon as we have an equivocating validator. The bitfields are uninitialized in the general case and are fast. The node-weight addition logic has been altered to avoid double-counting any equivocated votes.

The second, and probably most error-prone thing this does is to alter the logic for determining if a round is completable. The completable check sometimes needs to determine if any descendents of a block could possibly get 2/3+ vote-weight, and this PR alters the logic there to account for possible equivocations on blocks (i.e. not discounting any vote-weight which has already been spent).