### PR TITLE
Voting + round-change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 parking_lot = "0.4"
 log = "0.4"
 futures = "0.1"
+
+[dev-dependencies]
+tokio = "0.1.8"
+exit-future = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Parity Technologies <admin@parity.io>"]
 [dependencies]
 parking_lot = "0.4"
 log = "0.4"
+futures = "0.1"

--- a/src/bridge_state.rs
+++ b/src/bridge_state.rs
@@ -80,7 +80,6 @@ mod tests {
 
 	#[test]
 	fn bridging_state() {
-
 		let initial = RoundState {
 			prevote_ghost: None,
 			finalized: None,

--- a/src/bridge_state.rs
+++ b/src/bridge_state.rs
@@ -1,0 +1,73 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// This file is part of finality-afg.
+
+// finality-afg is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// finality-afg is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with finality-afg. If not, see <http://www.gnu.org/licenses/>.
+
+//! Bridging round state between rounds.
+
+use round::State as RoundState;
+use futures::task;
+use parking_lot::{RwLock, RwLockReadGuard};
+use std::sync::Arc;
+
+// round state bridged across rounds.
+struct Bridged<H> {
+	inner: RwLock<RoundState<H>>,
+	task: task::AtomicTask,
+}
+
+impl<H> Bridged<H> {
+	fn new(inner: RwLock<RoundState<H>>) -> Self {
+		Bridged {
+			inner,
+			task: task::AtomicTask::new(),
+		}
+	}
+}
+
+/// A prior view of a round-state.
+pub(crate) struct PriorView<H>(Arc<Bridged<H>>);
+
+impl<H> PriorView<H> {
+	/// Push an update to the latter view.
+	pub(crate) fn update(&self, new: RoundState<H>) {
+		*self.0.inner.write() = new;
+		self.0.task.notify();
+	}
+}
+
+/// A latter view of a round-state.
+pub(crate) struct LatterView<H>(Arc<Bridged<H>>);
+
+impl<H> LatterView<H> {
+	/// Fetch a handle to the last round-state.
+	pub(crate) fn get(&self) -> RwLockReadGuard<RoundState<H>> {
+		self.0.task.register();
+		self.0.inner.read()
+	}
+}
+
+/// Constructs two views of a bridged round-state.
+///
+/// The prior view is held by a round which produces the state and pushes updates to a latter view.
+/// When updating, the latter view's task is updated.
+///
+/// The latter view is held by the subsequent round, which blocks certain activity
+/// while waiting for events on an older round.
+pub(crate) fn bridge_state<H>(initial: RoundState<H>) -> (PriorView<H>, LatterView<H>) {
+	let inner = Arc::new(Bridged::new(RwLock::new(initial)));
+	(
+		PriorView(inner.clone()), LatterView(inner)
+	)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@
 //! https://hackmd.io/iA4XazxWRJ21LqMxwPSEZg?view
 
 extern crate parking_lot;
+
+#[macro_use]
+extern crate futures;
 #[macro_use]
 extern crate log;
 
@@ -97,4 +100,20 @@ pub struct Equivocation<Id, V, S> {
 	pub	first: (V, S),
 	/// The second vote in the equivocation.
 	pub second: (V, S),
+}
+
+/// A protocol message or vote.
+pub enum Message<H> {
+	/// A prevote message.
+	Prevote(Prevote<H>),
+	/// A precommit message.
+	Precommit(Precommit<H>),
+	// TODO: liveness-propose and commit messages.
+}
+
+/// A signed message.
+pub struct SignedMessage<H, S, Id> {
+	pub message: Message<H>,
+	pub signature: S,
+	pub id: Id,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,11 @@ extern crate futures;
 #[macro_use]
 extern crate log;
 
+#[cfg(test)]
+extern crate tokio;
+#[cfg(test)]
+extern crate exit_future;
+
 pub mod bitfield;
 pub mod round;
 pub mod vote_graph;
@@ -91,7 +96,9 @@ pub trait Chain<H> {
 	/// If the block is not a descendent of `base`, returns an error.
 	fn ancestry(&self, base: H, block: H) -> Result<Vec<H>, Error>;
 
-	/// Return the hash of the best block whose chain contains the given block hash.
+	/// Return the hash of the best block whose chain contains the given block hash,
+	/// even if that block is `base` itself.
+	///
 	/// If `base` is unknown, return `None`.
 	fn best_chain_containing(&self, base: H) -> Option<(H, usize)>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub mod round;
 pub mod vote_graph;
 pub mod voter;
 
+mod bridge_state;
+
 #[cfg(test)]
 mod testing;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,13 @@ impl<H> Precommit<H> {
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Error {
-	BlockNotInSubtree,
+	NotDescendent,
 }
 
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
-			Error::BlockNotInSubtree => write!(f, "Block not in subtree of base"),
+			Error::NotDescendent => write!(f, "Block not descendent of base"),
 		}
 	}
 }
@@ -76,7 +76,7 @@ impl fmt::Display for Error {
 impl ::std::error::Error for Error {
 	fn description(&self) -> &str {
 		match *self {
-			Error::BlockNotInSubtree => "Block not in subtree of base",
+			Error::NotDescendent => "Block not descendent of base",
 		}
 	}
 }
@@ -88,6 +88,10 @@ pub trait Chain<H> {
 	///
 	/// If the block is not a descendent of `base`, returns an error.
 	fn ancestry(&self, base: H, block: H) -> Result<Vec<H>, Error>;
+
+	/// Return the hash of the best block whose chain contains the given block hash.
+	/// If `base` is unknown, return `None`.
+	fn best_chain_containing(&self, base: H) -> Option<(H, usize)>;
 }
 
 /// An equivocation (double-vote) in a given round.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ extern crate log;
 pub mod bitfield;
 pub mod round;
 pub mod vote_graph;
+pub mod voter;
 
 #[cfg(test)]
 mod testing;

--- a/src/round.rs
+++ b/src/round.rs
@@ -473,6 +473,11 @@ impl<Id, H, Signature> Round<Id, H, Signature> where
 	pub fn threshold(&self) -> usize {
 		threshold(self.total_weight, self.faulty_weight)
 	}
+
+	/// Return the round base.
+	pub fn base(&self) -> (H, usize) {
+		self.graph.base()
+	}
 }
 
 fn threshold(total_weight: usize, faulty_weight: usize) -> usize {

--- a/src/round.rs
+++ b/src/round.rs
@@ -173,6 +173,7 @@ impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone> VoteTracker<Id, 
 }
 
 /// State of the round.
+#[derive(PartialEq, Clone)]
 pub struct State<H> {
 	/// The prevote-GHOST block.
 	pub prevote_ghost: Option<(H, usize)>,

--- a/src/round.rs
+++ b/src/round.rs
@@ -184,6 +184,18 @@ pub struct State<H> {
 	pub completable: bool,
 }
 
+impl<H: Clone> State<H> {
+	// Genesis state.
+	pub fn genesis(genesis: (H, usize)) -> Self {
+		State {
+			prevote_ghost: Some(genesis.clone()),
+			finalized: Some(genesis.clone()),
+			estimate: Some(genesis),
+			completable: true,
+		}
+	}
+}
+
 /// Parameters for starting a round.
 pub struct RoundParams<Id: Hash + Eq, H> {
 	/// The round number for votes.

--- a/src/round.rs
+++ b/src/round.rs
@@ -240,7 +240,7 @@ impl<Id, H, Signature> Round<Id, H, Signature> where
 	}
 
 	/// Return the round number.
-	pub fn number(&self) -> usize {
+	pub fn number(&self) -> u64 {
 		self.round_number
 	}
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -635,7 +635,7 @@ mod tests {
 			Prevote::new("FC", 10),
 			"Eve",
 			Signature("Eve-1"),
-		).unwrap().equivocation.is_none());
+		).unwrap().is_none());
 
 
 		assert!(round.prevote_ghost.is_none());
@@ -645,14 +645,14 @@ mod tests {
 			Prevote::new("ED", 10),
 			"Eve",
 			Signature("Eve-2"),
-		).unwrap().equivocation.is_some());
+		).unwrap().is_some());
 
 		assert!(round.import_prevote(
 			&chain,
 			Prevote::new("F", 7),
 			"Eve",
 			Signature("Eve-2"),
-		).unwrap().equivocation.is_some());
+		).unwrap().is_some());
 
 		// three eves together would be enough.
 
@@ -663,7 +663,7 @@ mod tests {
 			Prevote::new("FA", 8),
 			"Bob",
 			Signature("Bob-1"),
-		).unwrap().equivocation.is_none());
+		).unwrap().is_none());
 
 		assert_eq!(round.prevote_ghost, Some(("FA", 8)));
 	}

--- a/src/round.rs
+++ b/src/round.rs
@@ -239,6 +239,11 @@ impl<Id, H, Signature> Round<Id, H, Signature> where
 		}
 	}
 
+	/// Return the round number.
+	pub fn number(&self) -> usize {
+		self.round_number
+	}
+
 	/// Import a prevote. Returns an equivocation proof if the vote is an equivocation.
 	///
 	/// Should not import the same prevote more than once.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -17,7 +17,14 @@
 //! Helpers for testing
 
 use std::collections::HashMap;
-use super::{Chain, Error};
+
+use round::State as RoundState;
+use voter::RoundData;
+use tokio::timer::Delay;
+use parking_lot::Mutex;
+use futures::prelude::*;
+use futures::sync::mpsc;
+use super::{Chain, Error, Equivocation, Message, Prevote, Precommit, SignedMessage};
 
 pub const GENESIS_HASH: &str = "genesis";
 const NULL_HASH: &str = "NULL";
@@ -30,6 +37,7 @@ struct BlockRecord {
 pub struct DummyChain {
 	inner: HashMap<&'static str, BlockRecord>,
 	leaves: Vec<&'static str>,
+	finalized: (&'static str, usize),
 }
 
 impl DummyChain {
@@ -37,7 +45,11 @@ impl DummyChain {
 		let mut inner = HashMap::new();
 		inner.insert(GENESIS_HASH, BlockRecord { number: 1, parent: NULL_HASH });
 
-		DummyChain { inner, leaves: vec![GENESIS_HASH] }
+		DummyChain {
+			inner,
+			leaves: vec![GENESIS_HASH],
+			finalized: (GENESIS_HASH, 1),
+		}
 	}
 
 	pub fn push_blocks(&mut self, mut parent: &'static str, blocks: &[&'static str]) {
@@ -73,6 +85,10 @@ impl DummyChain {
 	pub fn number(&self, hash: &'static str) -> usize {
 		self.inner.get(hash).unwrap().number
 	}
+
+	pub fn last_finalized(&self) -> (&'static str, usize) {
+		self.finalized.clone()
+	}
 }
 
 impl Chain<&'static str> for DummyChain {
@@ -102,6 +118,10 @@ impl Chain<&'static str> for DummyChain {
 			let leaf_number = self.inner.get(leaf).unwrap().number;
 			if leaf_number < base_number { break }
 
+			if leaf == &base {
+				return Some((leaf, leaf_number))
+			}
+
 			if let Ok(_) = self.ancestry(base, leaf) {
 				return Some((leaf, leaf_number));
 			}
@@ -109,4 +129,115 @@ impl Chain<&'static str> for DummyChain {
 
 		None
 	}
+}
+
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Id(pub usize);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature(usize);
+
+pub struct Environment {
+	chain: Mutex<DummyChain>,
+	voters: HashMap<Id, usize>,
+	local_id: Id,
+	listeners: Mutex<Vec<mpsc::UnboundedSender<(&'static str, usize)>>>,
+}
+
+impl Environment {
+	pub fn new(voters: HashMap<Id, usize>, local_id: Id) -> Self {
+		Environment {
+			chain: Mutex::new(DummyChain::new()),
+			voters,
+			local_id,
+			listeners: Mutex::new(Vec::new()),
+		}
+	}
+
+	pub fn with_chain<F, U>(&self, f: F) -> U where F: FnOnce(&mut DummyChain) -> U {
+		let mut chain = self.chain.lock();
+		f(&mut *chain)
+	}
+
+	/// Stream of finalized blocks.
+	pub fn finalized_stream(&self) -> mpsc::UnboundedReceiver<(&'static str, usize)> {
+		let (tx, rx) = mpsc::unbounded();
+		self.listeners.lock().push(tx);
+		rx
+	}
+}
+
+impl Chain<&'static str> for Environment {
+	fn ancestry(&self, base: &'static str, block: &'static str) -> Result<Vec<&'static str>, Error> {
+		self.chain.lock().ancestry(base, block)
+	}
+
+	fn best_chain_containing(&self, base: &'static str) -> Option<(&'static str, usize)> {
+		self.chain.lock().best_chain_containing(base)
+	}
+}
+
+impl ::voter::Environment<&'static str> for Environment {
+	type Timer = Box<Future<Item=(),Error=Error> + Send + 'static>;
+	type Id = Id;
+	type Signature = Signature;
+	type In = Box<Stream<Item=SignedMessage<&'static str, Signature, Id>,Error=Error> + Send + 'static>;
+	type Out = Box<Sink<SinkItem=Message<&'static str>,SinkError=Error> + Send + 'static>;
+	type Error = Error;
+
+	fn round_data(&self, round: u64) -> RoundData<Self::Timer, Self::Id, Self::In, Self::Out> {
+		use std::time::{Instant, Duration};
+		const GOSSIP_DURATION: Duration = Duration::from_millis(500);
+
+		let now = Instant::now();
+		let (incoming, outgoing) = make_comms(self.local_id);
+		RoundData {
+			prevote_timer: Box::new(Delay::new(now + GOSSIP_DURATION)
+				.map_err(|_| panic!("Timer failed"))),
+			precommit_timer: Box::new(Delay::new(now + GOSSIP_DURATION + GOSSIP_DURATION)
+				.map_err(|_| panic!("Timer failed"))),
+			voters: self.voters.clone(),
+			incoming: Box::new(incoming),
+			outgoing: Box::new(outgoing),
+		}
+	}
+
+	fn completed(&self, _round: u64, _state: RoundState<&'static str>) { }
+
+	fn finalize_block(&self, hash: &'static str, number: u32) {
+		let mut chain = self.chain.lock();
+
+		if number as usize <= chain.finalized.1 { panic!("Attempted to finalize backwards") }
+		assert!(chain.ancestry(chain.finalized.0, hash).is_ok(), "Safety violation: reverting finalized block.");
+		chain.finalized = (hash, number as _);
+		self.listeners.lock().retain(|s| s.unbounded_send((hash, number as _)).is_ok());
+	}
+
+	fn prevote_equivocation(&self, round: u64, equivocation: Equivocation<Id, Prevote<&'static str>, Signature>) {
+		panic!("Encountered equivocation in round {}: {:?}", round, equivocation);
+	}
+
+	fn precommit_equivocation(&self, round: u64, equivocation: Equivocation<Id, Precommit<&'static str>, Signature>) {
+		panic!("Encountered equivocation in round {}: {:?}", round, equivocation);
+	}
+}
+
+// TODO: replace this with full-fledged dummy network.
+fn make_comms(local_id: Id) -> (
+	impl Stream<Item=SignedMessage<&'static str, Signature, Id>,Error=Error>,
+	impl Sink<SinkItem=Message<&'static str>,SinkError=Error>
+)
+{
+	let (tx, rx) = mpsc::unbounded();
+	let tx = tx
+		.sink_map_err(|e| panic!("Error sending messages: {:?}", e))
+		.with(move |message| Ok(SignedMessage {
+			message,
+			signature: Signature(local_id.0),
+			id: local_id,
+		}));
+
+	let rx = rx.map_err(|e| panic!("Error receiving messages: {:?}", e));
+
+	(rx, tx)
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -185,7 +185,7 @@ impl ::voter::Environment<&'static str> for Environment {
 	type Out = Box<Sink<SinkItem=Message<&'static str>,SinkError=Error> + Send + 'static>;
 	type Error = Error;
 
-	fn round_data(&self, round: u64) -> RoundData<Self::Timer, Self::Id, Self::In, Self::Out> {
+	fn round_data(&self, _round: u64) -> RoundData<Self::Timer, Self::Id, Self::In, Self::Out> {
 		use std::time::{Instant, Duration};
 		const GOSSIP_DURATION: Duration = Duration::from_millis(500);
 

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -80,6 +80,7 @@ pub struct VoteGraph<H: Hash + Eq, V> {
 	entries: HashMap<H, Entry<H, V>>,
 	heads: HashSet<H>,
 	base: H,
+	base_number: usize,
 }
 
 impl<H, V> VoteGraph<H, V> where
@@ -103,7 +104,13 @@ impl<H, V> VoteGraph<H, V> where
 			entries,
 			heads,
 			base: base_hash,
+			base_number,
 		}
+	}
+
+	/// Get the base block.
+	pub fn base(&self) -> (H, usize) {
+		(self.base.clone(), self.base_number)
 	}
 
 	/// Insert a vote with given value into the graph at given hash and number.

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -348,7 +348,9 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 
 		if last_state.finalized != new_state.finalized && new_state.completable {
 			// send notification only when the round is completable and we've cast votes.
-			// this is a workaround for avoiding restarting the round based on
+			// this is a workaround that ensures when we re-instantiate the voter after
+			// a shutdown, we never re-create the same round with a base that was finalized
+			// in this round or after.
 			match (&self.state, new_state.finalized) {
 				(&Some(State::Precommitted), Some(ref f)) => {
 					let _ = self.finalized_sender.unbounded_send(f.clone());

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -366,8 +366,9 @@ impl<H, E: Environment<H>> Future for BackgroundRound<H, E>
 	}
 }
 
-/// A future that maintains and multiplexes between different rounds.
-pub struct ActiveRounds<H, E: Environment<H>>
+/// A future that maintains and multiplexes between different rounds,
+/// and caches votes.
+pub struct Voter<H, E: Environment<H>>
 	where H: Hash + Clone + Eq + Ord + ::std::fmt::Debug
 {
 	env: Arc<E>,
@@ -376,10 +377,10 @@ pub struct ActiveRounds<H, E: Environment<H>>
 	finalized_notifications: UnboundedReceiver<u32>,
 }
 
-impl<H, E: Environment<H>> ActiveRounds<H, E>
+impl<H, E: Environment<H>> Voter<H, E>
 	where H: Hash + Clone + Eq + Ord + ::std::fmt::Debug
 {
-	/// Create new `ActiveRounds` tracker with given round number and base block.
+	/// Create new `Voter` tracker with given round number and base block.
 	///
 	/// Provide data about the last completed round. If there is no
 	/// known last completed round, the genesis state (round number 0),
@@ -416,7 +417,7 @@ impl<H, E: Environment<H>> ActiveRounds<H, E>
 			primary_block: None,
 		};
 
-		ActiveRounds {
+		Voter {
 			env,
 			best_round,
 			past_rounds: FuturesUnordered::new(),
@@ -441,7 +442,7 @@ impl<H, E: Environment<H>> ActiveRounds<H, E>
 	}
 }
 
-impl<H, E: Environment<H>> Future for ActiveRounds<H, E>
+impl<H, E: Environment<H>> Future for Voter<H, E>
 	where H: Hash + Clone + Eq + Ord + ::std::fmt::Debug
 {
 	type Item = ();

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -126,7 +126,7 @@ pub struct VotingRound<H, E: Environment<H>> where H: Hash + Clone + Eq + Ord + 
 impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + ::std::fmt::Debug {
 	fn poll(&mut self, env: &E) -> Poll<(), E::Error> {
 		let mut state = self.votes.state();
-		while let Some(incoming) = try_ready!(self.incoming.poll()) {
+		while let Async::Ready(Some(incoming)) = self.incoming.poll()? {
 			let SignedMessage { message, signature, id } = incoming;
 
 			match message {

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -1,0 +1,147 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// This file is part of finality-afg.
+
+// finality-afg is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// finality-afg is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with finality-afg. If not, see <http://www.gnu.org/licenses/>.
+
+//! A voter in AfG. This transitions between rounds and casts votes.
+//!
+//! Voters rely on some external context to function:
+//!   - setting timers to cast votes
+//!   - incoming vote streams
+//!   - providing voter weights.
+
+use futures::prelude::*;
+use std::hash::Hash;
+use ::Client;
+
+/// Necessary environment for a voter.
+pub trait Environment: Chain<Self::Hash> {
+	type Timer: IntoFuture<Item=(),Error=Self::Error>;
+	type Id: Hash + Clone + Eq + ::std::fmt::Debug;
+	type Signature: Eq + Clone;
+	type H: Hash + Clone + Eq + Ord + ::std::fmt::Debug;
+	type In: Stream<Item=SignedMessage<Self::Hash, Self::Signature, Self::Id>,Error=Self::Error>;
+	type Out: Sink<SinkItem=Message<Self::Hash>,SinkError=Self::Error>;
+	type Error: From<::Error>;
+
+	/// Produce data necessary to start a round of voting.
+	fn round_data(&self, round: usize) -> RoundData<
+		Self::Timer,
+		Self::Id,
+		Self::Signature,
+		Self::In,
+		Self::Out
+	>;
+}
+
+/// Data necessary to participate in a round.
+pub struct RoundData<Timer, Id, Signature, Input, Outgoing> {
+	/// Timer before prevotes can be cast. This should be Start + 2T
+	/// where T is the gossip time estimate.
+	pub prevote_timer: Timer,
+	/// Timer before precommits can be cast. This should be Start + 4T
+	pub precommit_timer: Timer,
+	/// All voters in this round.
+	pub voters: HashMap<Id, usize>,
+	/// Incoming messages.
+	pub incoming: Input,
+	/// Outgoing messages.
+	pub outgoing: Output,
+}
+
+enum State<T> {
+	Start(T, T),
+	Prevoted(T),
+	Precommitted,
+}
+
+/// Logic for a voter.
+pub struct VotingRound<E: Environment> {
+	tracker: Round<E::Id, E::H, E::Signature>,
+	incoming: E::Incoming,
+	outgoing: E::Outgoing,
+	state: Option<State<E::Timer>>,
+}
+
+impl<E: Environment> VotingRound<E> {
+	fn poll(&mut self, env: &E) -> Poll<(), E::Error> {
+		while let Some(incoming) = try_ready!(self.incoming.poll()) {
+			let ::SignedMessage { message, signature, id } = incoming;
+
+			match message {
+				Message::Prevote(prevote) => {
+					// TODO: handle equivocation.
+					if let Some(e) = self.tracker.import_prevote(env, prevote, id, signature)? {
+
+					}
+				}
+				Message::Precommit(precommit) => {
+					// TODO: handle equivocation.
+					if let Some(e) = self.tracker.import_precommit(env, prevote, id, signature)? {
+
+					}
+				}
+			}
+		}
+
+		self.prevote()?;
+		self.precommit()?;
+	}
+
+	fn prevote(&mut self) -> Result<(), E::Error> {
+		match self.state.take() {
+			Some(State::Start(mut prevote_timer, precommit_timer)) => {
+				let should_prevote = match prevote_timer.poll() {
+					Err(e) => return Err(e),
+					Ok(Async::Ready(())) => true,
+					Ok(Async::NotReady) => self.tracker.completable(),
+				};
+
+				if should_prevote {
+					// TODO: cast prevote.
+					self.state = Some(State::Prevoted(precommit_timer));
+					unimplemented!();
+				} else {
+					self.state = Some(State::Start(prevote_timer, precommit_timer));
+				}
+			}
+			x => { self.state = x; }
+		}
+
+		Ok(())
+	}
+
+	fn precommit(&mut self) -> Result<(), E::Error> {
+		match self.state.take() {
+			Some(State::Prevoted(mut precommit_timer)) => {
+				let should_precommit = match precommit_timer.poll() {
+					Err(e) => return Err(e),
+					Ok(Async::Ready(())) => true,
+					Ok(Async::NotReady) => self.tracker.completable(),
+				};
+
+				if should_precommit {
+					// TODO: cast precommit.
+					self.state = Some(State::Precommitted);
+					unimplemented!();
+				} else {
+					self.state = Some(State::Prevoted(precommit_timer));
+				}
+			}
+			x => { self.state = x; }
+		}
+
+		Ok(())
+	}
+}

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -520,8 +520,7 @@ impl<H, E: Environment<H>> Future for Voter<H, E>
 		let should_start_next = match self.best_round.poll()? {
 			Async::Ready(()) => match self.best_round.state {
 				Some(State::Precommitted) => true, // start when we've cast all votes.
-				_ => panic!("Returns ready only when round completable and messages flushed; \
-					completable implies precommit sent; qed"),
+				_ => false,
 			},
 			Async::NotReady => false,
 		};

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -194,7 +194,7 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 				};
 
 				if should_precommit {
-					let precommit = self.construct_precommit(env)?;
+					let precommit = self.construct_precommit(env);
 					self.outgoing.push(Message::Precommit(precommit));
 					self.state = Some(State::Precommitted);
 				} else {
@@ -268,8 +268,15 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 	}
 
 	// construct a precommit message based on local state.
-	fn construct_precommit(&self, env: &E) -> Result<Precommit<H>, E::Error> {
+	fn construct_precommit(&self, env: &E) -> Precommit<H> {
+		let t = match self.votes.state().prevote_ghost {
+			Some(target) => target,
+			None => self.votes.base(),
+		};
 
-		unimplemented!()
+		Precommit {
+			target_hash: t.0,
+			target_number: t.1 as u32,
+		}
 	}
 }

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -577,7 +577,7 @@ impl<H, E: Environment<H>> Future for Voter<H, E>
 mod tests {
 	use super::*;
 	use tokio::runtime::current_thread;
-	use testing::{GENESIS_HASH, DummyChain, Environment, Id};
+	use testing::{GENESIS_HASH, Environment, Id};
 	use std::collections::HashMap;
 
 	#[test]
@@ -608,7 +608,7 @@ mod tests {
 			// wait for the best block to finalize.
 			finalized
 				.take_while(|&(_, n)| Ok(n < 6))
-				.for_each(|n| Ok(()))
+				.for_each(|_| Ok(()))
 		})).unwrap();
 	}
 }

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -24,7 +24,7 @@
 use futures::prelude::*;
 use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
-use round::Round;
+use round::{Round, State as RoundState};
 
 use ::{Chain, Equivocation, Message, Prevote, Precommit, SignedMessage};
 
@@ -121,6 +121,8 @@ pub struct VotingRound<H, E: Environment<H>> where H: Hash + Clone + Eq + Ord + 
 	incoming: E::In,
 	outgoing: Buffered<E::Out>,
 	state: Option<State<E::Timer>>,
+	last_round_state: RoundState<H>,
+	primary_block: Option<(H, usize)>,
 }
 
 impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + ::std::fmt::Debug {
@@ -147,8 +149,8 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 			state = next_state;
 		}
 
-		self.prevote()?;
-		self.precommit()?;
+		self.prevote(env)?;
+		self.precommit(env)?;
 
 		try_ready!(self.outgoing.poll());
 
@@ -159,7 +161,7 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 		}
 	}
 
-	fn prevote(&mut self) -> Result<(), E::Error> {
+	fn prevote(&mut self, env: &E) -> Result<(), E::Error> {
 		match self.state.take() {
 			Some(State::Start(mut prevote_timer, precommit_timer)) => {
 				let should_prevote = match prevote_timer.poll() {
@@ -169,7 +171,8 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 				};
 
 				if should_prevote {
-					self.outgoing.push(Message::Prevote(unimplemented!()));
+					let prevote = self.construct_prevote(env)?;
+					self.outgoing.push(Message::Prevote(prevote));
 					self.state = Some(State::Prevoted(precommit_timer));
 				} else {
 					self.state = Some(State::Start(prevote_timer, precommit_timer));
@@ -181,7 +184,7 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 		Ok(())
 	}
 
-	fn precommit(&mut self) -> Result<(), E::Error> {
+	fn precommit(&mut self, env: &E) -> Result<(), E::Error> {
 		match self.state.take() {
 			Some(State::Prevoted(mut precommit_timer)) => {
 				let should_precommit = match precommit_timer.poll() {
@@ -191,8 +194,8 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 				};
 
 				if should_precommit {
-					// TODO: cast precommit.
-					self.outgoing.push(Message::Precommit(unimplemented!()));
+					let precommit = self.construct_precommit(env)?;
+					self.outgoing.push(Message::Precommit(precommit));
 					self.state = Some(State::Precommitted);
 				} else {
 					self.state = Some(State::Prevoted(precommit_timer));
@@ -202,5 +205,71 @@ impl<H, E: Environment<H>> VotingRound<H, E> where H: Hash + Clone + Eq + Ord + 
 		}
 
 		Ok(())
+	}
+
+	// construct a prevote message based on local state.
+	fn construct_prevote(&self, env: &E) -> Result<Prevote<H>, E::Error> {
+		let last_round_estimate = self.last_round_state.estimate.clone()
+			.expect("Rounds only started when prior round completable; qed");
+
+		let find_descendent_of = match self.primary_block {
+			None => {
+				// vote for best chain containing prior round-estimate.
+				last_round_estimate.0
+			}
+			Some(ref primary_block) => {
+				// we will vote for the best chain containing `p_hash` iff
+				// the last round's prevote-GHOST included that block and
+				// that block is a strict descendent of the last round-estimate that we are
+				// aware of.
+				let last_prevote_g = self.last_round_state.prevote_ghost.clone()
+					.expect("Rounds only started when prior round completable; qed");
+
+				// if the blocks are equal, we don't check ancestry.
+				if primary_block == &last_prevote_g {
+					primary_block.0.clone()
+				} else if primary_block.1 >= last_prevote_g.1 {
+					last_round_estimate.0
+				} else {
+					// from this point onwards, the number of the primary-broadcasted
+					// block is less than the last prevote-GHOST's number.
+					// if the primary block is in the ancestry of p-G we vote for the
+					// best chain containing it.
+					let &(ref p_hash, p_num) = primary_block;
+					match env.ancestry(last_round_estimate.0.clone(), last_prevote_g.0) {
+						Ok(ancestry) => {
+							let offset = last_prevote_g.1.saturating_sub(p_num + 1);
+							if ancestry.get(offset).map_or(false, |b| b == p_hash) {
+								p_hash.clone()
+							} else {
+								last_round_estimate.0
+							}
+						}
+						Err(::Error::NotDescendent) => last_round_estimate.0,
+						Err(e) => return Err(e.into()),
+					}
+				}
+			}
+		};
+
+		let t = match env.best_chain_containing(find_descendent_of) {
+			Some(target) => target,
+			None => {
+				// TODO: throw error here. `find_descendent` should deal with only
+				// known blocks.
+				unimplemented!()
+			}
+		};
+
+		Ok(Prevote {
+			target_hash: t.0,
+			target_number: t.1 as u32,
+		})
+	}
+
+	// construct a precommit message based on local state.
+	fn construct_precommit(&self, env: &E) -> Result<Precommit<H>, E::Error> {
+
+		unimplemented!()
 	}
 }


### PR DESCRIPTION
This pull request implements the actual algorithm of the finality gadget, including choosing when to start rounds, how to react to messages, choosing blocks to cast votes on, and producing finality notifications.

Most of the changes here is the introduction of a `Voter` future, which relies on an `Environment` implementation for setting up timers and networking and to pass finality information to.

The `Voter` has a `best_round` and some `background_rounds` which are prior. Background rounds are kept and continued to be polled until a block with the same number as their round-estimate is finalized. This is safe because the round-estimate is a calculation of the best possible block that could be finalized in that round -- once we've finalized something equal to or beyond that point, the round becomes irrelevant.

This does pass on a lot of the work of correct communication to the `Environment` layer: all signing, message routing, and buffering of incoming messages is left outside of this crate for now (although creating some common utilities for that) may be useful in the future.